### PR TITLE
Remove Environment 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,15 +10,13 @@ let package = Package(
     ],
     products: [.library(name: "RazorpayKit", targets: ["RazorpayKit"])],
     dependencies: [
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.20.1"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.1.0")
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.21.2")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(name: "RazorpayKit", dependencies: [
-            .product(name: "AsyncHTTPClient", package: "async-http-client"),
-            .product(name: "Crypto", package: "swift-crypto"),
+            .product(name: "AsyncHTTPClient", package: "async-http-client")
         ]),
         .testTarget(
             name: "RazorpayKitTests",

--- a/Sources/RazorpayKit/RazorpayClient.swift
+++ b/Sources/RazorpayKit/RazorpayClient.swift
@@ -24,31 +24,31 @@ public final class RazorpayClient {
     public var transfer: RazorpayTransferRoutes
     public var virtualAccount: RazorpayVirtualAccountRoutes
     public var webhook: RazorpayWebhookRoutes
-    
+
     var handler: RazorpayAPIHandler
     
-    public init(httpClient: HTTPClient, key: String, secret: String, environment: Environment) {
-        self.handler = RazorpayAPIHandler(httpClient: httpClient, key: key, secret: secret, environment: environment)
-        account = RazorpayAccountRoutes(client: handler, baseUrl: environment.baseUrl)
-        addon = RazorpayAddonRoutes(client: handler, baseUrl: environment.baseUrl)
-        card = RazorpayCardRoutes(client: handler, baseUrl: environment.baseUrl)
-        customer = RazorpayCustomerRoutes(client: handler, baseUrl: environment.baseUrl)
-        fundAccount = RazorpayFundAccountRoutes(client: handler, baseUrl: environment.baseUrl)
-        iin = RazorpayIINRoutes(client: handler, baseUrl: environment.baseUrl)
-        invoice = RazorpayInvoiceRoutes(client: handler, baseUrl: environment.baseUrl)
-        item = RazorpayItemRoutes(client: handler, baseUrl: environment.baseUrl)
-        order = RazorpayOrderRoutes(client: handler, baseUrl: environment.baseUrl)
-        payment = RazorpayPaymentRoutes(client: handler, baseUrl: environment.baseUrl)
-        paymentLink = RazorpayPaymentLinkRoutes(client: handler, baseUrl: environment.baseUrl)
-        product = RazorpayProductRoutes(client: handler, baseUrl: environment.baseUrl)
-        qrCode = RazorpayQRCodeRoutes(client: handler, baseUrl: environment.baseUrl)
-        refund = RazorpayRefundRoutes(client: handler, baseUrl: environment.baseUrl)
-        settlement = RazorpaySettlementRoutes(client: handler, baseUrl: environment.baseUrl)
-        stakeholder = RazorpayStakeholderRoutes(client: handler, baseUrl: environment.baseUrl)
-        subscription = RazorpaySubscriptionRoutes(client: handler, baseUrl: environment.baseUrl)
-        token = RazorpayTokenRoutes(client: handler, baseUrl: environment.baseUrl)
-        transfer = RazorpayTransferRoutes(client: handler, baseUrl: environment.baseUrl)
-        virtualAccount = RazorpayVirtualAccountRoutes(client: handler, baseUrl: environment.baseUrl)
-        webhook = RazorpayWebhookRoutes(client: handler, baseUrl: environment.baseUrl)
+    public init(httpClient: HTTPClient, key: String, secret: String) {
+        self.handler = RazorpayAPIHandler(httpClient: httpClient, key: key, secret: secret)
+        account = RazorpayAccountRoutes(client: handler)
+        addon = RazorpayAddonRoutes(client: handler)
+        card = RazorpayCardRoutes(client: handler)
+        customer = RazorpayCustomerRoutes(client: handler)
+        fundAccount = RazorpayFundAccountRoutes(client: handler)
+        iin = RazorpayIINRoutes(client: handler)
+        invoice = RazorpayInvoiceRoutes(client: handler)
+        item = RazorpayItemRoutes(client: handler)
+        order = RazorpayOrderRoutes(client: handler)
+        payment = RazorpayPaymentRoutes(client: handler)
+        paymentLink = RazorpayPaymentLinkRoutes(client: handler)
+        product = RazorpayProductRoutes(client: handler)
+        qrCode = RazorpayQRCodeRoutes(client: handler)
+        refund = RazorpayRefundRoutes(client: handler)
+        settlement = RazorpaySettlementRoutes(client: handler)
+        stakeholder = RazorpayStakeholderRoutes(client: handler)
+        subscription = RazorpaySubscriptionRoutes(client: handler)
+        token = RazorpayTokenRoutes(client: handler)
+        transfer = RazorpayTransferRoutes(client: handler)
+        virtualAccount = RazorpayVirtualAccountRoutes(client: handler)
+        webhook = RazorpayWebhookRoutes(client: handler)
     }
 }

--- a/Sources/RazorpayKit/RazorpayRequest.swift
+++ b/Sources/RazorpayKit/RazorpayRequest.swift
@@ -4,20 +4,6 @@ import NIOFoundationCompat
 import NIOHTTP1
 import AsyncHTTPClient
 
-public enum Environment {
-    case production
-    case sandbox
-    
-    var baseUrl: String {
-        switch self {
-        case .production:
-            return APIConstants.baseURL
-        case .sandbox:
-            return APIConstants.baseURL
-        }
-    }
-}
-
 extension HTTPClientRequest.Body {
     public static func string(_ string: String) -> Self {
         .bytes(.init(string: string))
@@ -34,15 +20,13 @@ extension HTTPClientRequest.Body {
 
 struct RazorpayAPIHandler {
     private let httpClient: HTTPClient
-    private let environment: Environment
     private let key: String
     private let secret: String
     
-    public init(httpClient: HTTPClient, key: String, secret: String, environment: Environment) {
+    public init(httpClient: HTTPClient, key: String, secret: String) {
         self.httpClient = httpClient
         self.key = key
         self.secret = secret
-        self.environment = environment
     }
     
     private func authorizationHeader() -> String {
@@ -57,7 +41,7 @@ struct RazorpayAPIHandler {
                             headers: HTTPHeaders) async throws -> HTTPClientResponse {
         
         let queryString = RZPRUTL.convertToQueryString(queryParams)
-        let url = environment.baseUrl + path + queryString
+        let url = APIConstants.baseURL + path + queryString
         
         var requestHeaders: HTTPHeaders = ["Authorization": authorizationHeader(), "Content-Type": "application/json",
                                            "Accept": "application/json"]

--- a/Sources/RazorpayKit/Resources/Account.swift
+++ b/Sources/RazorpayKit/Resources/Account.swift
@@ -29,11 +29,9 @@ public protocol AccountRoutes: RazorpayAPIRoute {
 public struct RazorpayAccountRoutes: AccountRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     public func create(data: [String: Any], extraHeaders: [String: String]? = nil) async throws -> [String: Any] {

--- a/Sources/RazorpayKit/Resources/Addon.swift
+++ b/Sources/RazorpayKit/Resources/Addon.swift
@@ -20,11 +20,9 @@ public protocol AddonRoutes: RazorpayAPIRoute {
 public struct RazorpayAddonRoutes: AddonRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     public func fetch(addonID: String, queryParams: [String: String]? = nil, extraHeaders: [String: String]? = nil) async throws -> [String: Any] {

--- a/Sources/RazorpayKit/Resources/Card.swift
+++ b/Sources/RazorpayKit/Resources/Card.swift
@@ -17,11 +17,9 @@ public protocol CardRoutes: RazorpayAPIRoute {
 public struct RazorpayCardRoutes: CardRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     public func fetch(cardID: String, queryParams: [String: String]? = nil, extraHeaders: [String: String]? = nil) async throws -> [String: Any] {

--- a/Sources/RazorpayKit/Resources/Customer.swift
+++ b/Sources/RazorpayKit/Resources/Customer.swift
@@ -23,11 +23,9 @@ public protocol CustomerRoutes: RazorpayAPIRoute {
 public struct RazorpayCustomerRoutes: CustomerRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     public func fetch(customerID: String, queryParams: [String: String]? = nil, extraHeaders: [String: String]? = nil) async throws -> [String: Any] {

--- a/Sources/RazorpayKit/Resources/FundAccount.swift
+++ b/Sources/RazorpayKit/Resources/FundAccount.swift
@@ -17,11 +17,9 @@ public protocol FundAccountRoutes: RazorpayAPIRoute {
 public struct RazorpayFundAccountRoutes: FundAccountRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     public func all(queryParams: [String: String]? = nil, extraHeaders: [String: String]? = nil) async throws -> [String: Any] {

--- a/Sources/RazorpayKit/Resources/IIN.swift
+++ b/Sources/RazorpayKit/Resources/IIN.swift
@@ -14,11 +14,9 @@ public protocol IINRoutes: RazorpayAPIRoute {
 public struct RazorpayIINRoutes: IINRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     public func fetch(tokenIin: String, queryParams: [String: String]? = nil, extraHeaders: [String: String]? = nil) async throws -> [String: Any] {

--- a/Sources/RazorpayKit/Resources/Invoice.swift
+++ b/Sources/RazorpayKit/Resources/Invoice.swift
@@ -38,11 +38,9 @@ public protocol InvoiceRoutes: RazorpayAPIRoute {
 public struct RazorpayInvoiceRoutes: InvoiceRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     public func all(queryParams: [String: String]? = nil, extraHeaders: [String: String]? = nil) async throws -> [String: Any] {

--- a/Sources/RazorpayKit/Resources/Item.swift
+++ b/Sources/RazorpayKit/Resources/Item.swift
@@ -26,11 +26,9 @@ public protocol ItemRoutes: RazorpayAPIRoute {
 public struct RazorpayItemRoutes: ItemRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     public func all(queryParams: [String: String]? = nil, extraHeaders: [String: String]? = nil) async throws -> [String: Any] {

--- a/Sources/RazorpayKit/Resources/Order.swift
+++ b/Sources/RazorpayKit/Resources/Order.swift
@@ -49,11 +49,9 @@ public protocol OrderRoutes: RazorpayAPIRoute {
 public struct RazorpayOrderRoutes: OrderRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     // Fetches multiple orders for the given query parameters.

--- a/Sources/RazorpayKit/Resources/Payment.swift
+++ b/Sources/RazorpayKit/Resources/Payment.swift
@@ -74,11 +74,9 @@ public protocol PaymentRoutes: RazorpayAPIRoute {
 public struct RazorpayPaymentRoutes: PaymentRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     public func all(queryParams: [String: String]? = nil, extraHeaders: [String: String]? = nil) async throws -> [String: Any] {

--- a/Sources/RazorpayKit/Resources/PaymentLink.swift
+++ b/Sources/RazorpayKit/Resources/PaymentLink.swift
@@ -29,11 +29,9 @@ public protocol PaymentLinkRoutes: RazorpayAPIRoute {
 public struct RazorpayPaymentLinkRoutes: PaymentLinkRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     public func all(queryParams: [String: String]? = nil, extraHeaders: [String: String]? = nil) async throws -> [String: Any] {

--- a/Sources/RazorpayKit/Resources/Product.swift
+++ b/Sources/RazorpayKit/Resources/Product.swift
@@ -23,11 +23,9 @@ public protocol ProductRoutes: RazorpayAPIRoute {
 public struct RazorpayProductRoutes: ProductRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     public func requestProductConfiguration(accountId: String, data: [String: Any], extraHeaders: [String: String]? = nil) async throws -> [String: Any] {

--- a/Sources/RazorpayKit/Resources/QrCode.swift
+++ b/Sources/RazorpayKit/Resources/QrCode.swift
@@ -26,11 +26,9 @@ public protocol QRCodeRoutes: RazorpayAPIRoute {
 public struct RazorpayQRCodeRoutes: QRCodeRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     public func create(data: [String: Any], extraHeaders: [String: String]? = nil) async throws -> [String: Any] {

--- a/Sources/RazorpayKit/Resources/Refund.swift
+++ b/Sources/RazorpayKit/Resources/Refund.swift
@@ -23,11 +23,9 @@ public protocol RefundRoutes: RazorpayAPIRoute {
 public struct RazorpayRefundRoutes: RefundRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     public func all(queryParams: [String: String]? = nil, extraHeaders: [String: String]? = nil) async throws -> [String: Any] {

--- a/Sources/RazorpayKit/Resources/Settlement.swift
+++ b/Sources/RazorpayKit/Resources/Settlement.swift
@@ -29,11 +29,9 @@ public protocol SettlementRoutes: RazorpayAPIRoute {
 public struct RazorpaySettlementRoutes: SettlementRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     public func all(queryParams: [String: String]? = nil, extraHeaders: [String: String]? = nil) async throws -> [String: Any] {

--- a/Sources/RazorpayKit/Resources/Stakeholder.swift
+++ b/Sources/RazorpayKit/Resources/Stakeholder.swift
@@ -29,11 +29,9 @@ public protocol StakeholderRoutes: RazorpayAPIRoute {
 public struct RazorpayStakeholderRoutes: StakeholderRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     public func create(accountId: String, data: [String: Any], extraHeaders: [String: String]? = nil) async throws -> [String: Any] {

--- a/Sources/RazorpayKit/Resources/Subscription.swift
+++ b/Sources/RazorpayKit/Resources/Subscription.swift
@@ -44,11 +44,9 @@ public protocol SubscriptionRoutes: RazorpayAPIRoute {
 public struct RazorpaySubscriptionRoutes: SubscriptionRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     public func all(queryParams: [String: String]? = nil, extraHeaders: [String: String]? = nil) async throws -> [String: Any] {

--- a/Sources/RazorpayKit/Resources/Token.swift
+++ b/Sources/RazorpayKit/Resources/Token.swift
@@ -32,11 +32,9 @@ public protocol TokenRoutes: RazorpayAPIRoute {
 public struct RazorpayTokenRoutes: TokenRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     public func create(data: [String: Any], extraHeaders: [String: String]? = nil) async throws -> [String: Any] {

--- a/Sources/RazorpayKit/Resources/Transfer.swift
+++ b/Sources/RazorpayKit/Resources/Transfer.swift
@@ -29,11 +29,9 @@ public protocol TransferRoutes: RazorpayAPIRoute {
 public struct RazorpayTransferRoutes: TransferRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     public func all(queryParams: [String: String]? = nil, extraHeaders: [String: String]? = nil) async throws -> [String: Any] {

--- a/Sources/RazorpayKit/Resources/VirtualAccount.swift
+++ b/Sources/RazorpayKit/Resources/VirtualAccount.swift
@@ -35,11 +35,9 @@ public protocol VirtualAccountRoutes: RazorpayAPIRoute {
 public struct RazorpayVirtualAccountRoutes: VirtualAccountRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     public func all(queryParams: [String: String]? = nil, extraHeaders: [String: String]? = nil) async throws -> [String: Any] {

--- a/Sources/RazorpayKit/Resources/Webhook.swift
+++ b/Sources/RazorpayKit/Resources/Webhook.swift
@@ -26,11 +26,9 @@ public protocol WebhookRoutes: RazorpayAPIRoute {
 public struct RazorpayWebhookRoutes: WebhookRoutes {
     public var headers: HTTPHeaders = [:]
     private let client: RazorpayAPIHandler
-    private let baseUrl: String
 
-    init(client: RazorpayAPIHandler, baseUrl: String) {
+    init(client: RazorpayAPIHandler) {
         self.client = client
-        self.baseUrl = baseUrl
     }
     
     public func create(accountId: String, data: [String: Any], extraHeaders: [String: String]? = nil) async throws -> [String: Any] {

--- a/Tests/RazorpayKitTests/RazorpayKitTests.swift
+++ b/Tests/RazorpayKitTests/RazorpayKitTests.swift
@@ -11,7 +11,7 @@ final class RazorpayKitTests: XCTestCase {
     override func setUp() {
         super.setUp()
         httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
-        razorpayClient = RazorpayClient(httpClient: httpClient, key: "RAZORPAY_KEY", secret: "RAZORPAY_SECRET", environment: .sandbox)
+        razorpayClient = RazorpayClient(httpClient: httpClient, key: "RAZORPAY_KEY", secret: "RAZORPAY_SECRET")
     }
     
     func testThatOrdersAreFetchedWithPayments() async throws {


### PR DESCRIPTION
This PR simplifies the RazorpayAPIHandler by removing the Environment enum and the baseUrl parameter. Key changes include:

- Removed the Environment enum and its usage from RazorpayAPIHandler.
- Updated RazorpayClient routes to remove the baseUrl parameter.
- Updated tests to remove the baseUrl parameter.